### PR TITLE
Update README.md with corrected OLED Wiring Diagram

### DIFF
--- a/PCB/2400MHz/TX_SX1280_Super_Slim/README.md
+++ b/PCB/2400MHz/TX_SX1280_Super_Slim/README.md
@@ -81,5 +81,5 @@ Attach wires to SDA, SCK, GND and 3.3v.
 Add -DUSE_OLED_I2C to your defines.
 The module should activate on boot.
 
-<img width="494" alt="image" src="https://user-images.githubusercontent.com/43392862/157010894-05f176a0-af13-4dab-b7fc-4191f4f429aa.png">
+<img width="494" alt="image" src="https://i.imgur.com/7yuCOUp.png">
 


### PR DESCRIPTION
The previous picture in the README incorrectly showed the SCK and SDA of the OLED display wired to pins 33 and 32, which was not ideal since pin 32 is NC (not connected).

Updated the wiring diagram to correctly show SDA and SCK connected to pin 9 (GPIO33) and pin 8 (GPIO32).